### PR TITLE
Bump version to v1.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicSMT"
 uuid = "a0d8a0e1-65bc-4be1-9afb-79a704359442"
 authors = ["Shashi Gowda <shashigowda91@gmail.com>"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"


### PR DESCRIPTION
## Summary
- Bump version from 1.3.0 to 1.4.0 to trigger a new minor release registration, which will produce a stable docs build via Documenter.

## Test plan
- [ ] Merge PR
- [ ] Register v1.4.0 via JuliaRegistrator
- [ ] Verify stable docs deploy at https://juliasymbolics.github.io/SymbolicSMT.jl/stable/

🤖 Generated with [Claude Code](https://claude.com/claude-code)