### PR TITLE
Raise SymbolicUtils floor from 4 to 4.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Z3 = "06b161dc-0161-11ea-0f74-41f836f4024b"
 
 [compat]
 Symbolics = "7"
-SymbolicUtils = "4"
+SymbolicUtils = "4.3"
 Z3 = "1.0"
 julia = "1"
 


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

Raise `SymbolicUtils` floor from `4` to `4.3`.

Live SymbolicSMT 1.4.0 declares `Symbolics = "7"` and `SymbolicUtils = "4"`. Every registered Symbolics 7.x requires SymbolicUtils ≥ 4.3.0 (`["7.0.0"] SymbolicUtils = "4.3.0 - 4"` in General). Pinning the declared SU 4.0.0 is therefore unsatisfiable.

No code or package version change.

### Fail before

Isolated-depot Julia 1.10.11, `Pkg.develop` live default + pin `SymbolicUtils 4.0.0`:

```
Unsatisfiable requirements detected for package SymbolicUtils
 restricted to versions 4 by SymbolicSMT
 restricted to versions 4.0.0 by an explicit requirement
 restricted by compatibility requirements with Symbolics
   to versions: 4.3.0-4.45.0 — no versions left
```

### Pass after

Pin `SymbolicUtils 4.3.0` (pulls Symbolics 7.0.0):

```
RESOLVE_OK
LOAD_OK_HOST SymbolicSMT 1.4.0
LOAD_OK_PIN SymbolicUtils 4.3.0
```

First working registered version is **4.3.0** because it is the lower bound of every Symbolics 7 release (7.0.0 Compat.toml). 4.0.0–4.2.x have no overlapping Symbolics 7.

`Symbolics = "7"` is left unchanged: 7.0.0 resolves and the 4.3.0 graph loads.

Not verified here: full test suite or a live `julia-downgrade-compat` run (this repo has no Downgrade workflow).
